### PR TITLE
c++: update for latest seastar

### DIFF
--- a/src/client/main.cc
+++ b/src/client/main.cc
@@ -6,6 +6,7 @@
 
 #include <seastar/core/app-template.hh>
 #include <seastar/core/distributed.hh>
+#include <seastar/core/reactor.hh>
 #include <smf/histogram_seastar_utils.h>
 #include <smf/load_channel.h>
 #include <smf/load_generator.h>

--- a/src/server/main.cc
+++ b/src/server/main.cc
@@ -6,6 +6,7 @@
 
 #include <seastar/core/app-template.hh>
 #include <seastar/core/distributed.hh>
+#include <seastar/core/reactor.hh>
 #include <seastar/net/api.hh>
 #include <smf/histogram_seastar_utils.h>
 #include <smf/log.h>


### PR DESCRIPTION
This change is required if [smf#387](https://github.com/smfrpc/smf/pull/387) is merged with latest seastar or probably even with a little older one.